### PR TITLE
[nvim] introduce lsp

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -238,3 +238,6 @@ require("mason-lspconfig").setup_handlers {
     --     require("rust-tools").setup {}
     -- end
 }
+
+-- setup additional plugins about lsp
+require("fidget").setup()

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -207,7 +207,7 @@ keyset("n", "[g", "<Plug>(coc-diagnostic-prev)", { silent = true })
 keyset("n", "]g", "<Plug>(coc-diagnostic-next)", { silent = true })
 
 vim.g.coc_global_extensions = { 'coc-html', 'coc-json', 'coc-yaml', 'coc-yank', 'coc-vimlsp',
-  'coc-eslint', 'coc-rust-analyzer', 'coc-lua', 'coc-clangd', 'coc-docker', 'coc-spell-checker', 'coc-pyright', 'coc-yaml', 'coc-julia'}
+  'coc-eslint', 'coc-rust-analyzer', 'coc-clangd', 'coc-docker', 'coc-spell-checker', 'coc-pyright', 'coc-yaml', 'coc-julia'}
 
 -- rust.vim settings
 vim.cmd('syntax enable')

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -237,6 +237,17 @@ require("mason-lspconfig").setup_handlers {
     -- ["rust_analyzer"] = function ()
     --     require("rust-tools").setup {}
     -- end
+    ["lua_ls"] = function()
+      require("lspconfig").lua_ls.setup{
+        settings = {
+          Lua = {
+            diagnostics = {
+              globals = {"vim"}
+            }
+          }
+        }
+      }
+    end
 }
 
 -- setup additional plugins about lsp

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -214,4 +214,27 @@ vim.cmd('syntax enable')
 vim.cmd('filetype plugin indent on')
 vim.g.rustfmt_autosave = 1
 
+-- LSP config
+-- It's important that you set up the plugins in the following order:
+--
+-- 1. `mason.nvim`
 require("mason").setup()
+-- 2. `mason-lspconfig.nvim`
+require("mason-lspconfig").setup({
+  ensure_installed = {"lua_ls"}
+})
+-- 3. Setup servers via `lspconfig`
+-- Here, setup the servers automatically based on the installed servers.
+require("mason-lspconfig").setup_handlers {
+    -- The first entry (without a key) will be the default handler
+    -- and will be called for each installed server that doesn't have
+    -- a dedicated handler.
+    function (server_name) -- default handler (optional)
+        require("lspconfig")[server_name].setup {}
+    end,
+    -- Next, you can provide a dedicated handler for specific servers.
+    -- For example, a handler override for the `rust_analyzer`:
+    -- ["rust_analyzer"] = function ()
+    --     require("rust-tools").setup {}
+    -- end
+}

--- a/.config/nvim/lua/plugins/init.lua
+++ b/.config/nvim/lua/plugins/init.lua
@@ -39,5 +39,10 @@ return {
   {"JuliaEditorSupport/julia-vim"},
   -- nvim-dap
   {"rcarriga/nvim-dap-ui", dependencies = {"mfussenegger/nvim-dap", "nvim-neotest/nvim-nio"}},
-  {"williamboman/mason.nvim"},
+  -- lsp
+  {
+    "williamboman/mason.nvim",
+    "williamboman/mason-lspconfig.nvim",
+    "neovim/nvim-lspconfig",
+  }
 }

--- a/.config/nvim/lua/plugins/init.lua
+++ b/.config/nvim/lua/plugins/init.lua
@@ -44,5 +44,7 @@ return {
     "williamboman/mason.nvim",
     "williamboman/mason-lspconfig.nvim",
     "neovim/nvim-lspconfig",
-  }
+  },
+  -- additional plugins about lsp
+  {"j-hui/fidget.nvim"},
 }


### PR DESCRIPTION
# やりたいこと

CocからLSPに移行したい

# やったこと

### LSP関連のパッケージを導入
e732f4c3ccdf2ac740d7d03801831f7178357fa3

```
  {
    "williamboman/mason.nvim",
    "williamboman/mason-lspconfig.nvim",
    "neovim/nvim-lspconfig",
  },
```

### fidgetを導入
3f42f383140b07185fc40ef34aabd8ecf6e1b926

###  init.lua において `vim` がglobal variableとして認識されるように修正
9e27638836394b785043c8033dfeeb47e190817f

- デフォルトの設定だと "[Undefined global vim](https://www.reddit.com/r/neovim/comments/14qydy9/undefined_global_vim/)" が出て警告まみれになる
- `lua_ls` については `setup()` を以下のように呼び出し、"vim" を有効なグローバル変数として認識するようにする。

```
["lua_ls"] = function()
      require("lspconfig").lua_ls.setup{
        settings = {
          Lua = {
            diagnostics = {
              globals = {"vim"}
            }
          }
        }
      }
    end
```

### coc-luaを削除

f2fbdb5a395704b0980dea9d9c01430b843dd7e7

lua_lsが有効になったので、coc-luaを消した