### PR TITLE
nvim v10.0系列へのアップグレードとavanteの導入

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -199,7 +199,7 @@ vim.api.nvim_set_keymap('s', '<S-Tab>', 'vsnip#jumpable(-1) ? "<Plug>(vsnip-jump
 require("mason").setup()
 -- 2. `mason-lspconfig.nvim`
 require("mason-lspconfig").setup({
-  ensure_installed = {"lua_ls", "clangd", "rust_analyzer", "julials", "typst_lsp", "typos_lsp", "pyright"}
+  ensure_installed = {"lua_ls", "clangd", "rust_analyzer", "julials", "tinymist", "typos_lsp", "pyright"}
 })
 -- 3. Setup servers via `lspconfig`
 -- Here, setup the servers automatically based on the installed servers.

--- a/.config/nvim/lua/plugins/init.lua
+++ b/.config/nvim/lua/plugins/init.lua
@@ -67,5 +67,64 @@ return {
   {'hrsh7th/nvim-cmp'},
   -- lua repl
   {"ii14/neorepl.nvim"},
-  {"knsh14/vim-github-link"}
+  {"knsh14/vim-github-link"},
+  {
+    "yetone/avante.nvim",
+    event = "VeryLazy",
+    lazy = false,
+    version = false, -- Set this to "*" to always pull the latest release version, or set it to false to update to the latest code changes.
+    opts = {
+      -- add any opts here
+      -- for example
+      provider = "openai",
+      openai = {
+        endpoint = "https://api.openai.com/v1",
+        model = "gpt-4o", -- your desired model (or use gpt-4o, etc.)
+        timeout = 30000, -- timeout in milliseconds
+        temperature = 0, -- adjust if needed
+        max_tokens = 4096,
+      },
+    },
+    -- if you want to build from source then do `make BUILD_FROM_SOURCE=true`
+    build = "make",
+    -- build = "powershell -ExecutionPolicy Bypass -File Build.ps1 -BuildFromSource false" -- for windows
+    dependencies = {
+      "nvim-treesitter/nvim-treesitter",
+      "stevearc/dressing.nvim",
+      "nvim-lua/plenary.nvim",
+      "MunifTanjim/nui.nvim",
+      --- The below dependencies are optional,
+      "echasnovski/mini.pick", -- for file_selector provider mini.pick
+      "nvim-telescope/telescope.nvim", -- for file_selector provider telescope
+      "hrsh7th/nvim-cmp", -- autocompletion for avante commands and mentions
+      "ibhagwan/fzf-lua", -- for file_selector provider fzf
+      "nvim-tree/nvim-web-devicons", -- or echasnovski/mini.icons
+      "zbirenbaum/copilot.lua", -- for providers='copilot'
+      {
+        -- support for image pasting
+        "HakonHarnes/img-clip.nvim",
+        event = "VeryLazy",
+        opts = {
+          -- recommended settings
+          default = {
+            embed_image_as_base64 = false,
+            prompt_for_file_name = false,
+            drag_and_drop = {
+              insert_mode = true,
+            },
+            -- required for Windows users
+            use_absolute_path = true,
+          },
+        },
+      },
+      {
+        -- Make sure to set this up properly if you have lazy=true
+        'MeanderingProgrammer/render-markdown.nvim',
+        opts = {
+          file_types = { "markdown", "Avante" },
+        },
+        ft = { "markdown", "Avante" },
+      },
+    },
+  }
 }

--- a/.gitignore_
+++ b/.gitignore_
@@ -1,2 +1,3 @@
 .cache/
 .vim/
+*/.zshrc_private

--- a/.zshrc
+++ b/.zshrc
@@ -26,6 +26,14 @@ if [[ -d "$HOME/.zfunc" && ":$fpath:" != *":$HOME/.zfunc:"* ]]; then
     fpath+=("$HOME/.zfunc")
 fi
 
+# ~/.zshrc
+# 外部に公開したくない情報を書くファイル
+if [ -f ~/.zshrc_private ]; then
+    source ~/.zshrc_private
+else
+    echo "Warning: ~/.zshrc_private not found. Some configurations may be missing."
+fi
+
 # Set name of the theme to load --- if set to "random", it will
 # load a random theme each time oh-my-zsh is loaded, in which case,
 # to know which specific one was loaded, run: echo $RANDOM_THEME


### PR DESCRIPTION
# モチベーション

- https://github.com/yetone/avante.nvim を使ってAI powered editorを試してみたい
- requreimentとしてnvim v10.0以降へのアップグレードが必要

# 対応事項

- typst-lspがdeprecatedになっていたので、tinymist に切り替え: 64945536e170752947fdf927006e202dbc1ea92c
- avante.nvimを導入: 0c9d901d44d95163539c7ea69b417fd0c32c4cb5
- OpenAI APIの書き場所 (.zshrc_private) を呼ぶ処理を .zshrc に追加

# その他注意事項

- neovim v9.5のインストールは appimage 経由でやっていたので、v10へのアップグレードも同じやりかたに従っておく
  - https://github.com/neovim/neovim/blob/master/INSTALL.md#appimage-universal-linux-package
- 一回v9.5のneovimを消し飛ばすことになるので、各プラグインを復活させるためにアップグレード後に `:Lazy` してプラグインを再度Syncしておく