### PR TITLE
feat(nvim): Add jj escape mapping in insert mode

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -273,6 +273,9 @@ if vim.g.vscode then
   end, { noremap = true, silent = true })
 -- Native Neovimだけで使うもの
 else
+  -- insert modeからの離脱
+  vim.keymap.set('i', 'jj', '<ESC>', { noremap = true, silent = true })
+
   -- window split
   vim.keymap.set('n', 'ss', ':split<Return><C-w>w')
   vim.keymap.set('n', 'sv', ':vsplit<Return><C-w>w')
@@ -308,4 +311,3 @@ else
   vim.keymap.set("n", "[e", "<cmd>Lspsaga diagnostic_jump_next<CR>")
   vim.keymap.set("n", "]e", "<cmd>Lspsaga diagnostic_jump_prev<CR>")
 end
-


### PR DESCRIPTION
# 概要
Native Neovimでinsert modeからjjで素早くescapeできるようにするkeymapを追加

# 背景と目的
- Escapeキーは物理的に遠い位置にあり、頻繁に使用するinsert modeからの離脱操作が非効率
- jjというキーシーケンスは:
  1. ホームポジションから入力が容易
  2. 通常の文章入力で連続してjjと入力することは稀であり、誤爆が少ない
  3. Vimユーザー間で広く採用されている慣習的な設定

# 実装の詳細
- Native Neovimのみで有効な設定として実装（VSCode-Neovimでは独自のキーマップ処理があるため除外）
- `noremap = true`を設定し、再帰的なマッピングを防止
- `silent = true`を設定し、コマンドラインへの表示を抑制

# 影響範囲
- Native Neovimユーザーのinsert mode操作のみに影響
- 既存の設定や他のキーマップへの影響なし