### PR TITLE
Add tmux attach alias 'ta'

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -135,6 +135,7 @@ source $ZSH/oh-my-zsh.sh
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 alias e="echo -n"
 alias t="tmux"
+alias ta="tmux attach"
 alias v="nvim"
 alias yank="win32yank.exe -i"
 


### PR DESCRIPTION
## Summary
- Add shorthand alias `ta` for the commonly used `tmux attach` command
- Improves developer efficiency by reducing keystrokes for a frequent operation

## Test plan
- [ ] Source the updated `.zshrc` file: `source ~/.zshrc`
- [ ] Test the new alias by running `ta` when a tmux session exists
- [ ] Verify it behaves identically to `tmux attach`

🤖 Generated with [Claude Code](https://claude.ai/code)