### PR TITLE
Expand allowed bash commands in Claude settings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,10 @@
   "permissions": {
     "allow": [
       "Bash(find:*)",
-      "Bash(ls:*)"
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(echo:*)",
+      "Bash(grep:*)"
     ],
     "deny": []
   }


### PR DESCRIPTION
## Summary
- Added `cat`, `echo`, and `grep` to the allowed bash commands in `.claude/settings.local.json`
- This enables Claude to perform more file operations and text processing tasks

## Test plan
- [x] Verify that the JSON syntax is valid
- [ ] Test that Claude can use the newly allowed commands
- [ ] Ensure no security concerns with the expanded permissions

🤖 Generated with [Claude Code](https://claude.ai/code)