### PR TITLE
tmux: add vim keybindings for copy mode

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -27,3 +27,12 @@ bind h select-pane -L
 bind j select-pane -D
 bind k select-pane -U
 bind l select-pane -R
+
+# vim mode
+setw -g mode-keys vi
+
+# vim-like copy mode
+bind -T copy-mode-vi v send -X begin-selection
+bind -T copy-mode-vi y send -X copy-selection-and-cancel
+bind -T copy-mode-vi Enter send -X copy-selection-and-cancel
+bind -T copy-mode-vi Escape send -X cancel


### PR DESCRIPTION
## Summary
- tmuxのコピーモードでvimキーバインドを使えるようにしました
- `v`で選択開始、`y`でコピーなど、vimと同じ操作感で使えます

## Changes
- `setw -g mode-keys vi`でviモードを有効化
- コピーモードのキーバインドを追加:
  - `v`: 選択開始
  - `y`: コピーして終了
  - `Enter`: コピーして終了
  - `Escape`: キャンセル

## Test plan
- [ ] tmuxを再起動または`tmux source-file ~/.tmux.conf`で設定を再読み込み
- [ ] `Ctrl+a [`でコピーモードに入る
- [ ] `hjkl`で移動できることを確認
- [ ] `v`で選択開始、`y`でコピーできることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)