### PR TITLE
add: Claude user memory configuration support

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,9 @@
+# Claude User Memory
+
+## Language Preference
+ユーザーとの対話は日本語で行う。すべての回答、説明、コメントは日本語で提供すること。
+
+## Communication Style
+- 技術的な内容でも日本語で説明
+- コードコメントも日本語で記述
+- エラーメッセージやログの説明も日本語で提供

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,9 @@ This is a personal dotfiles repository designed for WSL2 (Windows Subsystem for 
 
 ### Installation
 ```bash
-# Install all dotfiles (WARNING: forcibly overwrites existing files)
+# Clone and install (WARNING: forcibly overwrites existing files)
+git clone https://github.com/suzuki-toshihir0/dotfiles.git
+cd dotfiles
 make
 
 # Install specific configurations
@@ -18,9 +20,13 @@ make zsh     # Zsh configuration only
 make tmux    # Tmux configuration only
 make git     # Git configuration only
 make nvim    # Neovim configuration only
+make claude  # Claude user memory configuration only
 
 # Install HackGen Console NF font
 cd font && make
+
+# Enable rustup tab completion (if using Rust)
+rustup completions zsh > ~/.zfunc/_rustup
 ```
 
 ### Development
@@ -59,9 +65,14 @@ The repository uses GNU Make to create symbolic links from the repository to the
    - win32yank for clipboard sharing between WSL and Windows
    - Git credential manager integration for seamless authentication
 
+5. **Claude User Memory (.claude/CLAUDE.md)**
+   - Language preference settings for Claude Code interactions
+   - Communication style preferences (Japanese language)
+
 ### Important Notes
 
 - **Forceful Overwriting**: The Makefile uses `ln -sf` which forcefully overwrites existing dotfiles without backup
 - **Privacy**: Create `.zshrc_private` for sensitive configurations (API keys, tokens)
-- **Dependencies**: Requires neovim (latest via AppImage recommended), tmux, zsh with Oh My Zsh, fzf
+- **Dependencies**: Requires neovim (latest via AppImage recommended - see https://github.com/neovim/neovim/blob/master/INSTALL.md#appimage-universal-linux-package), tmux, zsh with Oh My Zsh, fzf
 - **Font**: HackGen Console NF provides Nerd Font icons and Japanese character support
+- **Clipboard Integration**: win32yank enables clipboard sharing between WSL and Windows (see win32yank/README.md for installation)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: zsh tmux git nvim
+all: zsh tmux git nvim claude
 
 zsh:
 	ln -sf $(PWD)/.zshrc $(HOME)/.zshrc
@@ -18,3 +18,7 @@ nvim:
 	ln -sf $(PWD)/.config/nvim/init.lua $(HOME)/.config/nvim/init.lua
 	find $(HOME)/.config/nvim/lua/plugins -maxdepth 1 -type l -delete
 	ln -sf $(PWD)/.config/nvim/lua/plugins/ $(HOME)/.config/nvim/lua/
+
+claude:
+	mkdir -p $(HOME)/.claude
+	ln -sf $(PWD)/.claude/CLAUDE.md $(HOME)/.claude/CLAUDE.md


### PR DESCRIPTION
## Summary
- Claudeのユーザーメモリ設定を追加（日本語での対話設定）
- Makefileに`claude`ターゲットを追加してユーザーメモリファイルの自動セットアップを可能にした
- ドキュメントを更新して新しい`make claude`コマンドを記載

## Test plan
- [ ] `make claude`でユーザーメモリファイルが正しく~/.claude/CLAUDE.mdに配置されることを確認
- [ ] `make`で全設定（claudeを含む）が正しくインストールされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)