### PR TITLE
zsh: add npm global bin directory to PATH

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -21,6 +21,10 @@ if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
     export PATH="$HOME/.local/bin:$PATH"
 fi
 
+if [[ ":$PATH:" != *":$HOME/.npm-global/bin:"* ]]; then
+    export PATH="$HOME/.npm-global/bin:$PATH"
+fi
+
 # Add ~/.zfunc to fpath if not already included
 if [[ -d "$HOME/.zfunc" && ":$fpath:" != *":$HOME/.zfunc:"* ]]; then
     fpath+=("$HOME/.zfunc")


### PR DESCRIPTION
## Summary
- npm install -g でインストールしたグローバルコマンドにアクセスできるよう ~/.npm-global/bin を PATH に追加

## Test plan
- [ ] .zshrc の変更内容を確認
- [ ] PATH に ~/.npm-global/bin が適切に追加されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)