### PR TITLE
feat: 環境に応じたGit credential helperの自動切り替え機能を追加

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -2,9 +2,8 @@
 	name = Toshihiro Suzuki
 	email = suzuki@arkedgespace.com
 
-[credential]
-  helper = "/mnt/c/Program\\ Files/Git/mingw64/bin/git-credential-manager.exe"
-  helper = "/usr/lib/git-core/git-credential-libsecret"
+[includeIf "gitdir/i:~/"]
+	path = ~/.gitconfig_os
 
 [alias]
 	co  = checkout

--- a/.gitconfig_linux
+++ b/.gitconfig_linux
@@ -1,0 +1,2 @@
+[credential]
+	helper = "/usr/lib/git-core/git-credential-libsecret"

--- a/.gitconfig_wsl
+++ b/.gitconfig_wsl
@@ -1,0 +1,2 @@
+[credential]
+	helper = "/mnt/c/Program\\ Files/Git/mingw64/bin/git-credential-manager.exe"

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ git:
 	ln -s -f ${PWD}/.gitconfig_linux ${HOME}/.gitconfig_linux
 	ln -s -f ${PWD}/.gitconfig_wsl ${HOME}/.gitconfig_wsl
 	ln -s -f ${PWD}/.gitignore_ ${HOME}/.gitignore
+	@OS=$$(${PWD}/detect_os.sh); \
+	if [ "$$OS" = "wsl" ]; then \
+		ln -sf ${HOME}/.gitconfig_wsl ${HOME}/.gitconfig_os; \
+	else \
+		ln -sf ${HOME}/.gitconfig_linux ${HOME}/.gitconfig_os; \
+	fi
 
 nvim:
 	mkdir -p $(HOME)/.config/nvim

--- a/detect_os.sh
+++ b/detect_os.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# WSL環境かどうかを検出
+if grep -qi microsoft /proc/version 2>/dev/null; then
+    echo "wsl"
+else
+    echo "linux"
+fi


### PR DESCRIPTION
## Summary
- WSL2とLinux環境でGit credential helperを自動的に切り替える機能を実装
- 環境検出スクリプトと環境別設定ファイルを追加
- `make git`実行時に自動的に適切なcredential helperが設定される

## Test plan
- [ ] WSL2環境で`make git`を実行し、Windows Git Credential Managerが設定されることを確認
- [ ] Linux環境で`make git`を実行し、libsecretが設定されることを確認
- [ ] `git config --get-all credential.helper`で正しいhelperが表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)