### PR TITLE
fix: yankエイリアスを環境に応じて動的に設定

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -142,7 +142,15 @@ alias t="tmux"
 alias ta="tmux attach"
 alias tn="tmux new -s"
 alias v="nvim"
-alias yank="win32yank.exe -i"
+
+# クリップボードエイリアス（環境に応じて切り替え）
+if grep -qi microsoft /proc/version 2>/dev/null; then
+    # WSL2環境
+    alias yank="win32yank.exe -i"
+else
+    # Linux環境（Wayland）
+    alias yank="wl-copy"
+fi
 
 # custom commands
 ide() {


### PR DESCRIPTION
## Summary
- yankエイリアスがWSL2環境でしか動作しない問題を修正
- 環境を自動検出して適切なクリップボードツールを使用

## Changes
- WSL2環境: `win32yank.exe -i` を使用（従来通り）
- Linux環境: `wl-copy` を使用（Wayland対応）
- `/proc/version`でMicrosoft文字列を検出してWSL2を判定

## Test plan
- [ ] WSL2環境で `echo "test" | yank` が動作することを確認
- [ ] Linux環境（Wayland）で `echo "test" | yank` が動作することを確認
- [ ] 両環境でクリップボードにテキストがコピーされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)