### PR TITLE
add: エディタ環境変数の設定を追加

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -127,11 +127,15 @@ source $ZSH/oh-my-zsh.sh
 # export LANG=en_US.UTF-8
 
 # Preferred editor for local and remote sessions
-# if [[ -n $SSH_CONNECTION ]]; then
-#   export EDITOR='vim'
-# else
-#   export EDITOR='mvim'
-# fi
+if [[ -n $SSH_CONNECTION ]]; then
+  export EDITOR='vim'
+  export VISUAL='vim'
+  export SUDO_EDITOR='vim'
+else
+  export EDITOR='nvim'
+  export VISUAL='nvim'
+  export SUDO_EDITOR='nvim'
+fi
 
 # Compilation flags
 # export ARCHFLAGS="-arch x86_64"


### PR DESCRIPTION
## Summary
- SSH接続時は軽量なvimを使用
- ローカル環境では設定済みのnvimを使用
- EDITOR、VISUAL、SUDO_EDITORの3つの環境変数を適切に設定

## Test plan
- [ ] SSH接続時にvimが起動することを確認
- [ ] ローカル環境でnvimが起動することを確認
- [ ] sudoeditコマンドで適切なエディタが起動することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)